### PR TITLE
Support ES 7

### DIFF
--- a/data/mapping-6.json
+++ b/data/mapping-6.json
@@ -1,6 +1,6 @@
 {
   "mappings": {
-    "_doc": {
+    "record": {
       "properties": {
         "application": {
           "properties": {


### PR DESCRIPTION
This adds logic to switch between specifying a document type and ignoring it or using the default `_doc` - as of ES7+ specifying types was removed with the recommendation being only having a single data type per index.